### PR TITLE
Fixed issue of blur radius and spread radius is swapped for initial shadow

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -26,12 +26,12 @@ const initialState = {
       id: Math.floor(Math.random() * 100) + 1,
       xOffset: 10,
       yOffset: 10,
-      spread: 10,
       blurRadius: 0,
+      spread: 10,
       opacity: 0.5,
       shadowColor: '#d20050',
       isActive: true,
-      boxShadow: '10px 10px 10px 0px rgba(210,0,80,0.5)'
+      boxShadow: '10px 10px 0px 10px rgba(210,0,80,0.5)'
     }
   ],
   previewColor: '#C22256',


### PR DESCRIPTION
1.The shadow shown on preview when app loads should be according to the slider values.

2.The CSS code displayed when app loads should be according to the slider values.